### PR TITLE
(bugfix): update path of `git-process-output.zsh`

### DIFF
--- a/za-submods-atclone-handler
+++ b/za-submods-atclone-handler
@@ -22,7 +22,7 @@ for mod in "${mods[@]}"; do
     fi
 
     command git -C "$dir" clone --progress "${parts[1]}" "${parts[2]}" |& \
-        ${ZINIT[BIN_DIR]}/git-process-output.zsh
+        ${ZINIT[BIN_DIR]}/share/git-process-output.zsh
 done
 
 # vim:ft=zsh:sts=4:sw=4:et


### PR DESCRIPTION
The [commit c0f14512a0d041989f64260eaed054f7a3370d50](https://github.com/zdharma-continuum/zinit/commit/c0f14512a0d041989f64260eaed054f7a3370d50) moved `git-process-output.zsh`